### PR TITLE
Fixed `mix test` failing on optional dependencies

### DIFF
--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -1,1 +1,2 @@
+Enum.map([:hackney, :tzdata], &Application.ensure_all_started/1)
 ExUnit.start(exclude: [integration: true])


### PR DESCRIPTION
Closes #4.