### PR TITLE
Change example datetimes

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,7 +146,7 @@ CalDAV specification defines a way to retrieve all events that meet certain crit
 
 ```elixir
 from = DateTime.from_naive!(~N[2021-01-01 00:00:00], "Europe/Warsaw")
-to = DateTime.from_naive!(~N[2021-01-31 23:59:59], "Europe/Warsaw")
+to = DateTime.from_naive!(~N[2021-02-01 00:00:00], "Europe/Warsaw")
 
 {:ok, events} = client |> CalDAVClient.Event.get_events(calendar_url, from, to)
 ```

--- a/examples/events.ex
+++ b/examples/events.ex
@@ -8,7 +8,7 @@ client = %CalDAVClient.Client{
 calendar_url = CalDAVClient.URL.Builder.build_calendar_url("username", "default")
 
 from = DateTime.from_naive!(~N[2021-02-01 00:00:00], "Europe/Warsaw")
-to = DateTime.from_naive!(~N[2021-02-28 23:59:59], "Europe/Warsaw")
+to = DateTime.from_naive!(~N[2021-03-01 00:00:00], "Europe/Warsaw")
 
 {:ok, events} = client |> CalDAVClient.Event.get_events(calendar_url, from, to, expand: false)
 events |> IO.inspect(label: "get_events, expand: false")


### PR DESCRIPTION
Time range is end-exclusive, so I changed the datetimes in the examples from 23:59:59 to 00:00:00 to avoid confusion.